### PR TITLE
Fix model selection for UI OpenAI adapter

### DIFF
--- a/keep-ui/app/api/copilotkit/route.ts
+++ b/keep-ui/app/api/copilotkit/route.ts
@@ -12,11 +12,13 @@ export const POST = async (req: NextRequest) => {
       const openai = new OpenAI({
         organization: process.env.OPEN_AI_ORGANIZATION_ID,
         apiKey: process.env.OPEN_AI_API_KEY,
+      });
+      const serviceAdapter = new OpenAIAdapter({
+        openai,
         ...(process.env.OPENAI_MODEL_NAME
           ? { model: process.env.OPENAI_MODEL_NAME }
           : {}),
       });
-      const serviceAdapter = new OpenAIAdapter({ openai });
       const runtime = new CopilotRuntime();
       return { runtime, serviceAdapter };
     } catch (error) {


### PR DESCRIPTION
## Summary
- connect Keep UI's OpenAI adapter with OPENAI_MODEL_NAME

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mysql')*

------
https://chatgpt.com/codex/tasks/task_e_6849ccf94fe08323aa8b212df324ba79